### PR TITLE
Prefab rotation and reflection.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "thirdParty/EAStdC"]
 	path = thirdParty/EAStdC
 	url = https://github.com/electronicarts/EAStdC.git
+[submodule "thirdParty/nlohmann_json"]
+	path = thirdParty/nlohmann_json
+	url = https://github.com/nlohmann/json

--- a/vertexy/CMakeLists.txt
+++ b/vertexy/CMakeLists.txt
@@ -30,6 +30,7 @@ file(GLOB VERTEXY_SOURCES
 add_subdirectory(../thirdParty/EABase ./thirdParty/EABase)
 add_subdirectory(../thirdParty/eastl ./thirdParty/eastl)
 add_subdirectory(../thirdParty/EAAssert ./thirdParty/EAAssert)
+add_subdirectory(../thirdParty/nlohmann_json ./thirdParty/nlohmann_json)
 
 file(GLOB_RECURSE VERTEXY_HEADERS "*.h")
 
@@ -38,6 +39,6 @@ target_compile_definitions(EAAssert PRIVATE _CRT_SECURE_NO_WARNINGS)
 
 add_library(VertexyLib ${VERTEXY_SOURCES} ${VERTEXY_HEADERS})
 target_compile_definitions(VertexyLib PUBLIC VERTEXY_SANITY_CHECKS=$<CONFIG:Debug>)
-target_link_libraries(VertexyLib EASTL EAAssert)
+target_link_libraries(VertexyLib EASTL EAAssert nlohmann_json::nlohmann_json)
 target_include_directories(VertexyLib PRIVATE "src/private")
 target_include_directories(VertexyLib PUBLIC "src/public")

--- a/vertexy/src/private/prefab/Prefab.cpp
+++ b/vertexy/src/private/prefab/Prefab.cpp
@@ -5,10 +5,11 @@
 #include "ConstraintTypes.h"
 #include "prefab/PrefabManager.h"
 #include "variable/SolverVariableDomain.h"
+#include "prefab/Tile.h"
 
 using namespace Vertexy;
 
-Prefab::Prefab(int inID, shared_ptr<PrefabManager> inManager, const vector<vector<int>>& inTiles)
+Prefab::Prefab(int inID, shared_ptr<PrefabManager> inManager, const vector<vector<Tile>> inTiles)
 {
 	m_id = inID;
 	m_manager = inManager;
@@ -23,7 +24,7 @@ Prefab::Prefab(int inID, shared_ptr<PrefabManager> inManager, const vector<vecto
 		for (int y = 0; y < m_tiles[x].size(); y++)
 		{
 			// Skip elements that aren't in the prefab
-			if (m_tiles[x][y] == INVALID_TILE)
+			if (m_tiles[x][y].id() == INVALID_TILE)
 			{
 				continue;
 			}
@@ -60,7 +61,7 @@ void Prefab::generatePrefabConstraints(ConstraintSolver* solver, const shared_pt
 
 		// Self
 		solver->makeGraphConstraint<ClauseConstraint>(grid, ENoGood::NoGood,
-			GraphRelationClause(selfTile, EClauseSign::Outside, { m_tiles[currLoc.x][currLoc.y] }),
+			GraphRelationClause(selfTile, EClauseSign::Outside, { m_tiles[currLoc.x][currLoc.y].id() }),
 			GraphRelationClause(selfTilePrefab, { m_id }),
 			GraphRelationClause(selfTilePrefabPos, { pos + 1 })
 		);
@@ -126,5 +127,54 @@ int Prefab::getTileValAtPos(int x, int y)
 {
 	vxy_assert(x >= 0 && x < m_tiles.size());
 	vxy_assert(y >= 0 && y < m_tiles[x].size());
-	return m_tiles[x][y];
+	return m_tiles[x][y].id();
+}
+
+void Prefab::rotate()
+{
+	transpose();
+	reverse();
+	for (int i = 0; i < m_tiles.size(); i++)
+	{
+		for (int j = 0; j < m_tiles[0].size(); j++)
+		{
+			m_tiles[i][j].rotate();
+		}
+	}
+}
+
+void Prefab::reflect()
+{
+	reverse();
+	for (int i = 0; i < m_tiles.size(); i++)
+	{
+		for (int j = 0; j < m_tiles[0].size(); j++)
+		{
+			m_tiles[i][j].reflect();
+		}
+	}
+}
+
+void Prefab::transpose()
+{
+	vector<vector<Tile>> tmp(m_tiles[0].size(), vector<Tile>());
+	for (int i = 0; i < m_tiles.size(); i++)
+	{
+		for (int j = 0; j < m_tiles[0].size(); j++)
+		{
+			tmp[j].push_back(m_tiles[i][j]);
+		}
+	}
+	m_tiles = tmp;
+}
+
+void Prefab::reverse()
+{
+	for (int i = 0; i < m_tiles.size(); i++)
+	{
+		for (int j = 0, k = m_tiles[0].size() - 1; j < k; j++, k--)
+		{
+			swap(m_tiles[i][j], m_tiles[i][k]);
+		}
+	}
 }

--- a/vertexy/src/private/prefab/Prefab.cpp
+++ b/vertexy/src/private/prefab/Prefab.cpp
@@ -9,102 +9,11 @@
 
 using namespace Vertexy;
 
-Prefab::Prefab(int inID, const vector<vector<Tile>> inTiles, bool rotation, bool reflection):
+Prefab::Prefab(int inID, const vector<vector<Tile>> inTiles):
 	m_id(inID),
 	m_tiles(inTiles)
 {
-	// Instantiate the positions
-	for (int x = 0; x < m_tiles.size(); x++)
-	{
-		for (int y = 0; y < m_tiles[x].size(); y++)
-		{
-			// Skip elements that aren't in the prefab
-			if (m_tiles[x][y].id() == INVALID_TILE)
-			{
-				continue;
-			}
-
-			m_positions.push_back(Position{ x,y });
-		}
-	}
-}
-
-void Prefab::generatePrefabConstraints(ConstraintSolver* solver, const shared_ptr<PlanarGridTopology>& grid, const shared_ptr<TTopologyVertexData<VarID>>& tileData)
-{
-	//auto selfTile = make_shared<TVertexToDataGraphRelation<VarID>>(ITopology::adapt(grid), tileData);
-	//auto selfTilePrefab = make_shared<TVertexToDataGraphRelation<VarID>>(ITopology::adapt(grid), m_manager->getTilePrefabData());
-	//auto selfTilePrefabPos = make_shared<TVertexToDataGraphRelation<VarID>>(ITopology::adapt(grid), m_manager->getTilePrefabPosData());
-
-	//// Ensure we have a real position if we have a prefab
-	//solver->makeGraphConstraint<ClauseConstraint>(grid, ENoGood::NoGood,
-	//	GraphRelationClause(selfTilePrefab, { m_id }),
-	//	GraphRelationClause(selfTilePrefabPos, { NO_PREFAB_POS })
-	//);
-
-	//// Ensure we don't use invalid values over this prefab's max
-	//for (int x = m_positions.size() + 1; x <= m_manager->getMaxPrefabSize(); x++)
-	//{
-	//	solver->makeGraphConstraint<ClauseConstraint>(grid, ENoGood::NoGood,
-	//		GraphRelationClause(selfTilePrefab, { m_id }),
-	//		GraphRelationClause(selfTilePrefabPos, { x })
-	//	);
-	//}
-	//
-	//for (int pos = 0; pos < m_positions.size(); pos++)
-	//{
-	//	Position currLoc = m_positions[pos];
-
-	//	// Self
-	//	solver->makeGraphConstraint<ClauseConstraint>(grid, ENoGood::NoGood,
-	//		GraphRelationClause(selfTile, EClauseSign::Outside, { m_tiles[currLoc.x][currLoc.y].id() }),
-	//		GraphRelationClause(selfTilePrefab, { m_id }),
-	//		GraphRelationClause(selfTilePrefabPos, { pos + 1 })
-	//	);
-
-	//	// Prev
-	//	if (pos > 0)
-	//	{
-	//		Position prevLoc = m_positions[pos - 1];
-	//		int diffX = currLoc.x - prevLoc.x;
-	//		int diffY = currLoc.y - prevLoc.y;
-	//		auto horizontalShift = make_shared<TopologyLinkIndexGraphRelation>(ITopology::adapt(grid), (diffY >= 0 ? PlanarGridTopology::moveLeft(diffY) : PlanarGridTopology::moveRight(-diffY)));
-	//		auto verticalShift = make_shared<TopologyLinkIndexGraphRelation>(ITopology::adapt(grid), (diffX >= 0 ? PlanarGridTopology::moveUp(diffX) : PlanarGridTopology::moveDown(-diffX)));
-
-	//		solver->makeGraphConstraint<ClauseConstraint>(grid, ENoGood::NoGood, GraphCulledVector<GraphRelationClause>::allOptional({
-	//				GraphRelationClause(selfTilePrefab, { m_id }),
-	//				GraphRelationClause(selfTilePrefabPos, { pos + 1 }),
-	//				GraphRelationClause(horizontalShift->map(verticalShift)->map(selfTilePrefab), EClauseSign::Outside, { m_id })
-	//		}));
-
-	//		solver->makeGraphConstraint<ClauseConstraint>(grid, ENoGood::NoGood, GraphCulledVector<GraphRelationClause>::allOptional({
-	//			GraphRelationClause(selfTilePrefab, { m_id }),
-	//			GraphRelationClause(selfTilePrefabPos, { pos + 1 }),
-	//			GraphRelationClause(horizontalShift->map(verticalShift)->map(selfTilePrefabPos), EClauseSign::Outside, { pos })
-	//		}));
-	//	}
-	//	
-	//	// Next
-	//	if (pos < m_positions.size() - 1)
-	//	{
-	//		Position nextLoc = m_positions[pos + 1];
-	//		int diffX = currLoc.x - nextLoc.x;
-	//		int diffY = currLoc.y - nextLoc.y;
-	//		auto horizontalShift = make_shared<TopologyLinkIndexGraphRelation>(ITopology::adapt(grid), (diffY >= 0 ? PlanarGridTopology::moveLeft(diffY) : PlanarGridTopology::moveRight(-diffY)));
-	//		auto verticalShift = make_shared<TopologyLinkIndexGraphRelation>(ITopology::adapt(grid), (diffX >= 0 ? PlanarGridTopology::moveUp(diffX) : PlanarGridTopology::moveDown(-diffX)));
-
-	//		solver->makeGraphConstraint<ClauseConstraint>(grid, ENoGood::NoGood, GraphCulledVector<GraphRelationClause>::allOptional({
-	//				GraphRelationClause(selfTilePrefab, { m_id }),
-	//				GraphRelationClause(selfTilePrefabPos, { pos + 1 }),
-	//				GraphRelationClause(horizontalShift->map(verticalShift)->map(selfTilePrefab), EClauseSign::Outside, { m_id })
-	//		}));
-
-	//		solver->makeGraphConstraint<ClauseConstraint>(grid, ENoGood::NoGood, GraphCulledVector<GraphRelationClause>::allOptional({
-	//			GraphRelationClause(selfTilePrefab, { m_id }),
-	//			GraphRelationClause(selfTilePrefabPos, { pos + 1 }),
-	//			GraphRelationClause(horizontalShift->map(verticalShift)->map(selfTilePrefabPos), EClauseSign::Outside, { pos + 2 })
-	//		}));
-	//	}
-	// }
+	updatePositions();
 }
 
 const Position& Prefab::getPositionForIndex(int index)
@@ -131,6 +40,7 @@ void Prefab::rotate(int times)
 	{
 		transpose();
 		reverse();
+		updatePositions();
 		for (int i = 0; i < m_tiles.size(); i++)
 		{
 			for (int j = 0; j < m_tiles[0].size(); j++)
@@ -145,6 +55,7 @@ void Prefab::rotate(int times)
 void Prefab::reflect()
 {
 	reverse();
+	updatePositions();
 	for (int i = 0; i < m_tiles.size(); i++)
 	{
 		for (int j = 0; j < m_tiles[0].size(); j++)
@@ -174,6 +85,23 @@ void Prefab::reverse()
 		for (int j = 0, k = m_tiles[0].size() - 1; j < k; j++, k--)
 		{
 			swap(m_tiles[i][j], m_tiles[i][k]);
+		}
+	}
+}
+
+void Prefab::updatePositions()
+{
+	m_positions.clear();
+	for (int x = 0; x < m_tiles.size(); x++)
+	{
+		for (int y = 0; y < m_tiles[x].size(); y++)
+		{
+			// Skip elements that aren't in the prefab
+			if (m_tiles[x][y].id() == INVALID_TILE)
+			{
+				continue;
+			}
+			m_positions.push_back(Position{ x,y });
 		}
 	}
 }

--- a/vertexy/src/private/prefab/Prefab.cpp
+++ b/vertexy/src/private/prefab/Prefab.cpp
@@ -49,7 +49,6 @@ void Prefab::rotate(int times)
 			}
 		}
 	}
-	
 }
 
 void Prefab::reflect()

--- a/vertexy/src/private/prefab/PrefabManager.cpp
+++ b/vertexy/src/private/prefab/PrefabManager.cpp
@@ -100,7 +100,7 @@ void PrefabManager::generatePrefabConstraints(const shared_ptr<TTopologyVertexDa
 		m_solver->makeGraphConstraint<ClauseConstraint>(m_grid, ENoGood::NoGood,
 			GraphRelationClause(selfTilePrefab, { prefab->id() }),
 			GraphRelationClause(selfTilePrefabPos, { Prefab::NO_PREFAB_POS })
-			);
+		);
 
 		// Ensure we don't use invalid values over this prefab's max
 		for (int x = prefab->positions().size() + 1; x <= getMaxPrefabSize(); x++)
@@ -108,7 +108,7 @@ void PrefabManager::generatePrefabConstraints(const shared_ptr<TTopologyVertexDa
 			m_solver->makeGraphConstraint<ClauseConstraint>(m_grid, ENoGood::NoGood,
 				GraphRelationClause(selfTilePrefab, { prefab->id() }),
 				GraphRelationClause(selfTilePrefabPos, { x })
-				);
+			);
 		}
 
 		for (int pos = 0; pos < prefab->positions().size(); pos++)
@@ -120,7 +120,7 @@ void PrefabManager::generatePrefabConstraints(const shared_ptr<TTopologyVertexDa
 				GraphRelationClause(selfTile, EClauseSign::Outside, { prefab->tiles()[currLoc.x][currLoc.y].id() }),
 				GraphRelationClause(selfTilePrefab, { prefab->id() }),
 				GraphRelationClause(selfTilePrefabPos, { pos + 1 })
-				);
+			);
 
 			// Prev
 			if (pos > 0)

--- a/vertexy/src/private/prefab/PrefabManager.cpp
+++ b/vertexy/src/private/prefab/PrefabManager.cpp
@@ -5,6 +5,7 @@
 #include "ConstraintTypes.h"
 #include "prefab/Prefab.h"
 #include "variable/SolverVariableDomain.h"
+#include "prefab/Tile.h"
 
 using namespace Vertexy;
 
@@ -24,7 +25,7 @@ PrefabManager::PrefabManager(ConstraintSolver* inSolver, const shared_ptr<Planar
 	m_grid = inGrid;
 }
 
-void PrefabManager::createPrefab(const vector<vector<int>>& inTiles)
+void PrefabManager::createPrefab(const vector<vector<Tile>>& inTiles)
 {
 	// Create the prefab with its unique ID
 	shared_ptr<Prefab> prefab = make_shared<Prefab>(m_prefabs.size() + 1, shared_from_this(), inTiles);
@@ -87,20 +88,23 @@ int PrefabManager::getMaxPrefabSize()
 
 void PrefabManager::createDefaultTestPrefab(int index)
 {
+	Tile tx(-1);
+	Tile t0(0);
+	Tile t1(1);
 	switch (index)
 	{
 	case 0: 
 		createPrefab({
-			{0, 0},
-			{1, 1}
+			{ t0, t0 },
+			{ t1, t1 }
 		});
 		break;
 
 	case 1:
 		createPrefab({
-			{ 1, -1, 1 },
-			{-1, -1, -1},
-			{ 1, -1, -1}
+			{ t1, tx, t1 },
+			{ tx, tx, tx },
+			{ t1, tx, tx }
 		});
 		break;
 

--- a/vertexy/src/private/prefab/PrefabManager.cpp
+++ b/vertexy/src/private/prefab/PrefabManager.cpp
@@ -39,10 +39,11 @@ void PrefabManager::createPrefab(const vector<vector<Tile>>& inTiles, bool allow
 	// Add to our internal list of prefabs
 	m_prefabs.push_back(prefab);
 
-	// if we allow rotation and/or reflection, create configurations
-	vector<shared_ptr<Prefab>> temp;
+	// if we allow rotation and/or reflection, create prefab configurations
 	if (!allowRotation && !allowReflection)
 		return;
+	
+	vector<shared_ptr<Prefab>> temp;
 	if (allowRotation && allowReflection)
 	{
 		for (int i = 0; i < 7; i++) { temp.push_back(make_shared<Prefab>(m_prefabs.size() + 1 + i, inTiles)); }
@@ -63,6 +64,7 @@ void PrefabManager::createPrefab(const vector<vector<Tile>>& inTiles, bool allow
 	}
 	else
 	{
+		//Create horizontal and vertical reflections.
 		for (int i = 0; i < 2; i++) { temp.push_back(make_shared<Prefab>(m_prefabs.size() + 1 + i, inTiles)); }
 		temp[0]->reflect();
 		temp[1]->rotate(2);

--- a/vertexy/src/private/prefab/PrefabManager.cpp
+++ b/vertexy/src/private/prefab/PrefabManager.cpp
@@ -30,15 +30,22 @@ void PrefabManager::createPrefab(const vector<vector<Tile>>& inTiles, bool allow
 	// Create the prefab with its unique ID
 	shared_ptr<Prefab> prefab = make_shared<Prefab>(m_prefabs.size() + 1, inTiles);
 
+	// Update the largest size for the domain
+	if (prefab->getNumTiles() > m_maxPrefabSize)
+	{
+		m_maxPrefabSize = prefab->getNumTiles();
+	}
 
+	// Add to our internal list of prefabs
+	m_prefabs.push_back(prefab);
 
-	/*vector<shared_ptr<Prefab>> temp;
+	// if we allow rotation and/or reflection, create configurations
+	vector<shared_ptr<Prefab>> temp;
 	if (!allowRotation && !allowReflection)
 		return;
-	
 	if (allowRotation && allowReflection)
 	{
-		for (int i = 0; i < 7; i++) { temp.push_back(prefab->clone()); }
+		for (int i = 0; i < 7; i++) { temp.push_back(make_shared<Prefab>(m_prefabs.size() + 1 + i, inTiles)); }
 		temp[0]->rotate(1);
 		temp[1]->rotate(2);
 		temp[2]->rotate(3);
@@ -49,30 +56,19 @@ void PrefabManager::createPrefab(const vector<vector<Tile>>& inTiles, bool allow
 	}
 	else if (allowRotation && !allowReflection)
 	{
-		for (int i = 0; i < 3; i++) { temp.push_back(prefab->clone()); }
+		for (int i = 0; i < 3; i++) { temp.push_back(make_shared<Prefab>(m_prefabs.size() + 1 + i, inTiles)); }
 		temp[0]->rotate(1);
 		temp[1]->rotate(2);
 		temp[2]->rotate(3);
 	}
 	else
 	{
-		for (int i = 0; i < 2; i++) { temp.push_back(prefab->clone()); }
+		for (int i = 0; i < 2; i++) { temp.push_back(make_shared<Prefab>(m_prefabs.size() + 1 + i, inTiles)); }
 		temp[0]->reflect();
+		temp[1]->rotate(2);
 		temp[1]->reflect();
-		temp[1]->rotate(3);
-	}*/
-
-
-
-
-	// Update the largest size for the domain
-	if (prefab->getNumTiles() > m_maxPrefabSize)
-	{
-		m_maxPrefabSize = prefab->getNumTiles();
 	}
-
-	// Add to our internal list of prefabs
-	m_prefabs.push_back(prefab);
+	m_prefabs.insert(m_prefabs.end(), temp.begin(), temp.end());
 }
 
 void PrefabManager::generatePrefabConstraints(const shared_ptr<TTopologyVertexData<VarID>>& tileData)
@@ -191,7 +187,7 @@ int PrefabManager::getMaxPrefabSize()
 	return m_maxPrefabSize;
 }
 
-void PrefabManager::createDefaultTestPrefab(int index)
+void PrefabManager::createDefaultTestPrefab(int index, bool rot, bool refl)
 {
 	Tile tx(-1);
 	Tile t0(0);
@@ -202,7 +198,7 @@ void PrefabManager::createDefaultTestPrefab(int index)
 		createPrefab({
 			{ t0, t0 },
 			{ t1, t1 }
-		});
+		}, rot, refl);
 		break;
 
 	case 1:
@@ -210,10 +206,9 @@ void PrefabManager::createDefaultTestPrefab(int index)
 			{ t1, tx, t1 },
 			{ tx, tx, tx },
 			{ t1, tx, tx }
-		});
+		}, rot, refl);
 		break;
 
 	default: vxy_assert(false);
 	}
-
 }

--- a/vertexy/src/private/prefab/Tile.cpp
+++ b/vertexy/src/private/prefab/Tile.cpp
@@ -5,8 +5,6 @@
 
 using namespace Vertexy;
 
-const Tile INVALID(-1);
-
 Tile::Tile(int id, string name, char symmetry, int configuration):
 	m_id(id),
 	m_name(name),

--- a/vertexy/src/private/prefab/Tile.cpp
+++ b/vertexy/src/private/prefab/Tile.cpp
@@ -11,6 +11,9 @@ Tile::Tile(int id, string name, char symmetry, int configuration):
 	m_symmetry(symmetry),
 	m_configuration(configuration)
 {
+	// This set of characters represents different types of tile symmetry,
+	// e.g. the letter "X" is symmetrical for all rotations and reflections.
+	// See the header file for a more detailed explanation.
 	vector<char> v = { 'X', 'I', '/', 'T', 'L', 'F' };
 	vxy_assert((find(v.begin(), v.end(), symmetry) != v.end()));
 	switch (symmetry)

--- a/vertexy/src/private/prefab/Tile.cpp
+++ b/vertexy/src/private/prefab/Tile.cpp
@@ -1,0 +1,65 @@
+// Copyright Proletariat, Inc. All Rights Reserved.
+#include "prefab/Tile.h"
+#include <EASTL/vector.h>
+#include "util/Asserts.h"
+
+using namespace Vertexy;
+
+const Tile INVALID(-1);
+
+Tile::Tile(int id, string name, char symmetry, int configuration):
+	m_id(id),
+	m_name(name),
+	m_symmetry(symmetry),
+	m_configuration(configuration)
+{
+	vector<char> v = { 'X', 'I', '/', 'T', 'L', 'F' };
+	vxy_assert((find(v.begin(), v.end(), symmetry) != v.end()));
+	switch (symmetry)
+	{
+	case 'X':
+		m_cardinality = 1;
+		m_a = [](int i) { vxy_assert(i < 1); return 0; };
+		m_b = [](int i) { vxy_assert(i < 1); return 0; };
+		break;
+	case 'I':
+		m_cardinality = 2;
+		m_a = [](int i) { vxy_assert(i < 2); return 1 - i; };
+		m_b = [](int i) { vxy_assert(i < 2); return i; };
+		break;
+	case '/':
+		m_cardinality = 2;
+		m_a = [](int i) { vxy_assert(i < 2); return 1 - i; };
+		m_b = [](int i) { vxy_assert(i < 2); return 1 - i; };
+		break;
+	case 'T':
+		m_cardinality = 4;
+		m_a = [](int i) { vxy_assert(i < 4); return (1 + i) % 4; };
+		m_b = [](int i) { vxy_assert(i < 4); return i % 2 == 0 ? i : 4 - i; };
+		break;
+	case 'L':
+		m_cardinality = 4;
+		m_a = [](int i) { vxy_assert(i < 4); return (1 + i) % 4; };
+		m_b = [](int i) { vxy_assert(i < 4); return 3 - i; };
+		break;
+	case 'F':
+		m_cardinality = 8;
+		m_a = [](int i) { vxy_assert(i < 8); return i < 4 ? (i + 1) % 4 : 4 + (i - 1) % 4; };
+		m_b = [](int i) { vxy_assert(i < 8); return i < 4 ? i + 4 : i - 4; };
+		break;
+	default:
+		m_cardinality = 1;
+		m_a = [](int i) { vxy_assert(i < 1); return 0; };
+		m_b = [](int i) { vxy_assert(i < 1); return 0; };
+	}
+}
+
+void Tile::rotate()
+{
+	m_configuration = m_a(m_configuration);
+}
+
+void Tile::reflect()
+{
+	m_configuration = m_b(m_configuration);
+}

--- a/vertexy/src/public/prefab/Prefab.h
+++ b/vertexy/src/public/prefab/Prefab.h
@@ -21,11 +21,7 @@ namespace Vertexy
 		static const int NO_PREFAB_ID = 0;
 		static const int NO_PREFAB_POS = 0;
 
-		Prefab(int inID, shared_ptr<PrefabManager> inManager, const vector<vector<Tile>> inTiles);
-		
-		Prefab(const Prefab& rhs) = delete;
-		Prefab(Prefab&& rhs) = delete;
-		Prefab& operator=(const Prefab& rhs) = delete;
+		Prefab(int inID, const vector<vector<Tile>> inTiles, bool rotation = false, bool reflection = false);
 		
 		// Given a solver, grid, and tileData, converts this prefab into a list of constraints and adds them to the solver
 		void generatePrefabConstraints(ConstraintSolver* solver, const shared_ptr<PlanarGridTopology>& grid, const shared_ptr<TTopologyVertexData<VarID>>& tileData);
@@ -40,12 +36,15 @@ namespace Vertexy
 		int getNumTiles();
 
 		// Rotate the prefab 90 degrees clockwise
-		void rotate();
+		void rotate(int times = 1);
 
 		// mirror the prefab horizontally
 		void reflect();
 
-
+		// getters
+		const int id() const { return m_id; };
+		const vector<Position> &positions() const { return m_positions; };
+		const vector<vector<Tile>> &tiles() const { return m_tiles; };
 
 	private:
 		// The tiles that make up the Prefab, in 2D array form; the indices represent the tile type
@@ -56,9 +55,6 @@ namespace Vertexy
 
 		// This prefab's identifier, uniquely assigned by its manager
 		int m_id;
-
-		// This prefab's manager
-		shared_ptr<PrefabManager> m_manager;
 
 		// Transpose the prefab
 		void transpose();

--- a/vertexy/src/public/prefab/Prefab.h
+++ b/vertexy/src/public/prefab/Prefab.h
@@ -7,6 +7,7 @@
 namespace Vertexy
 {
 	class PrefabManager;
+	class Tile;
 
 	struct Position
 	{
@@ -20,7 +21,7 @@ namespace Vertexy
 		static const int NO_PREFAB_ID = 0;
 		static const int NO_PREFAB_POS = 0;
 
-		Prefab(int inID, shared_ptr<PrefabManager> inManager, const vector<vector<int>>& inTiles);
+		Prefab(int inID, shared_ptr<PrefabManager> inManager, const vector<vector<Tile>> inTiles);
 		
 		Prefab(const Prefab& rhs) = delete;
 		Prefab(Prefab&& rhs) = delete;
@@ -38,9 +39,17 @@ namespace Vertexy
 		// Returns the number of tiles in this prefab
 		int getNumTiles();
 
+		// Rotate the prefab 90 degrees clockwise
+		void rotate();
+
+		// mirror the prefab horizontally
+		void reflect();
+
+
+
 	private:
 		// The tiles that make up the Prefab, in 2D array form; the indices represent the tile type
-		vector<vector<int>> m_tiles;
+		vector<vector<Tile>> m_tiles;
 
 		// A vector of {x,y} positions; each element of this vector represents the position at which that index's tile in the prefab is found
 		vector<Position> m_positions;
@@ -50,5 +59,11 @@ namespace Vertexy
 
 		// This prefab's manager
 		shared_ptr<PrefabManager> m_manager;
+
+		// Transpose the prefab
+		void transpose();
+
+		// Reverse the prefab row wise
+		void reverse();
 	};
 }

--- a/vertexy/src/public/prefab/Prefab.h
+++ b/vertexy/src/public/prefab/Prefab.h
@@ -21,10 +21,7 @@ namespace Vertexy
 		static const int NO_PREFAB_ID = 0;
 		static const int NO_PREFAB_POS = 0;
 
-		Prefab(int inID, const vector<vector<Tile>> inTiles, bool rotation = false, bool reflection = false);
-		
-		// Given a solver, grid, and tileData, converts this prefab into a list of constraints and adds them to the solver
-		void generatePrefabConstraints(ConstraintSolver* solver, const shared_ptr<PlanarGridTopology>& grid, const shared_ptr<TTopologyVertexData<VarID>>& tileData);
+		Prefab(int inID, const vector<vector<Tile>> inTiles);
 
 		// Returns the <x,y> grid position for the index-th tile in this prefab
 		const Position& getPositionForIndex(int index);
@@ -61,5 +58,7 @@ namespace Vertexy
 
 		// Reverse the prefab row wise
 		void reverse();
+
+		void updatePositions();
 	};
 }

--- a/vertexy/src/public/prefab/Prefab.h
+++ b/vertexy/src/public/prefab/Prefab.h
@@ -32,16 +32,16 @@ namespace Vertexy
 		// Returns the number of tiles in this prefab
 		int getNumTiles();
 
-		// Rotate the prefab 90 degrees clockwise
+		// Rotate the prefab 90 degrees clockwise N times
 		void rotate(int times = 1);
 
-		// mirror the prefab horizontally
+		// Mirror the prefab horizontally
 		void reflect();
 
-		// getters
+		// Getters
 		const int id() const { return m_id; };
-		const vector<Position> &positions() const { return m_positions; };
-		const vector<vector<Tile>> &tiles() const { return m_tiles; };
+		const vector<Position>& positions() const { return m_positions; };
+		const vector<vector<Tile>>& tiles() const { return m_tiles; };
 
 	private:
 		// The tiles that make up the Prefab, in 2D array form; the indices represent the tile type
@@ -59,6 +59,7 @@ namespace Vertexy
 		// Reverse the prefab row wise
 		void reverse();
 
+		// Set m_positions
 		void updatePositions();
 	};
 }

--- a/vertexy/src/public/prefab/PrefabManager.h
+++ b/vertexy/src/public/prefab/PrefabManager.h
@@ -37,7 +37,7 @@ namespace Vertexy
 		int getMaxPrefabSize();
 
 		// Create some basic sample prefabs used for testing
-		void createDefaultTestPrefab(int index);
+		void createDefaultTestPrefab(int index, bool rot = false, bool refl = false);
 
 	private:
 		PrefabManager(ConstraintSolver* inSolver, const shared_ptr<PlanarGridTopology>& inGrid);
@@ -47,10 +47,6 @@ namespace Vertexy
 
 		// The largest prefab associated with this manager (in terms of number of tiles in the prefab)
 		int m_maxPrefabSize;
-
-		// The original prefabs rotation/reflection associated with this manager
-		// It is counted as a different list to avoid shifting posterior prefabs ids
-		vector<shared_ptr<Prefab>> m_prefabs_configs;
 
 		// Correlation map for original prefabs and their rotated/reflected states
 		hash_map<int, vector<int>> prefabStateMap;

--- a/vertexy/src/public/prefab/PrefabManager.h
+++ b/vertexy/src/public/prefab/PrefabManager.h
@@ -19,7 +19,7 @@ namespace Vertexy
 		static shared_ptr<PrefabManager> create(ConstraintSolver* inSolver, const shared_ptr<PlanarGridTopology>& inGrid);
 		
 		// Creates a prefab and associates it with this manager
-		void createPrefab(const vector<vector<Tile>>& inTiles);
+		void createPrefab(const vector<vector<Tile>>& inTiles, bool allowRotation = false, bool allowReflection = false);
 
 		// Generates constraints for all prefabs associated with this manager
 		void generatePrefabConstraints(const shared_ptr<TTopologyVertexData<VarID>>& tileData);
@@ -47,6 +47,13 @@ namespace Vertexy
 
 		// The largest prefab associated with this manager (in terms of number of tiles in the prefab)
 		int m_maxPrefabSize;
+
+		// The original prefabs rotation/reflection associated with this manager
+		// It is counted as a different list to avoid shifting posterior prefabs ids
+		vector<shared_ptr<Prefab>> m_prefabs_configs;
+
+		// Correlation map for original prefabs and their rotated/reflected states
+		hash_map<int, vector<int>> prefabStateMap;
 
 		// The solver for which the prefab constraints will be created
 		ConstraintSolver* m_solver;

--- a/vertexy/src/public/prefab/PrefabManager.h
+++ b/vertexy/src/public/prefab/PrefabManager.h
@@ -7,6 +7,7 @@
 namespace Vertexy
 {
 	class Prefab;
+	class Tile;
 
 	class PrefabManager : public enable_shared_from_this<PrefabManager>
 	{
@@ -18,7 +19,7 @@ namespace Vertexy
 		static shared_ptr<PrefabManager> create(ConstraintSolver* inSolver, const shared_ptr<PlanarGridTopology>& inGrid);
 		
 		// Creates a prefab and associates it with this manager
-		void createPrefab(const vector<vector<int>>& inTiles);
+		void createPrefab(const vector<vector<Tile>>& inTiles);
 
 		// Generates constraints for all prefabs associated with this manager
 		void generatePrefabConstraints(const shared_ptr<TTopologyVertexData<VarID>>& tileData);

--- a/vertexy/src/public/prefab/Tile.h
+++ b/vertexy/src/public/prefab/Tile.h
@@ -1,0 +1,28 @@
+// Copyright Proletariat, Inc. All Rights Reserved.
+#pragma once
+#include <EASTL/string.h>
+
+namespace Vertexy
+{
+	using namespace eastl;
+
+	class Tile
+	{
+	public:
+		Tile(int id, string name = "", char symmetry = 'X', int configuration = 0);
+		void rotate();
+		void reflect();
+		const int id() const { return m_id; };
+		const int configuration() const { return m_configuration; };	
+		static const Tile INVALID;
+
+	private:
+		int m_id;
+		string m_name;
+		char m_symmetry;
+		int m_configuration;
+		int m_cardinality;
+		function<int(int)> m_a;
+		function<int(int)> m_b;
+	};
+}

--- a/vertexy/src/public/prefab/Tile.h
+++ b/vertexy/src/public/prefab/Tile.h
@@ -6,15 +6,32 @@ namespace Vertexy
 {
 	using namespace eastl;
 
+	// The symmetry of a square can be presented as:
+	//   D4 = < a,b : a^4 = b^2 = e, ab = ba^-1 >
+	// in which D4 is the group of symmetries (Dihedral group) of the square, <a> represents a 90
+	// degree rotation, <b> represents horizontal reflection and <e> its identity.
+	// A square has in total a set of 8 symmetries and can be composed as:
+	//   [e, ea, ea^2, ea^3, eb, eba, eba^2, eba^3]
+	// We can enumerate them as configuration 0 to 7.
+	// When using square tiles, some of those compositions are not symmetric, and we can represent
+	// those asymmetries with the characters X, I, /, T, L and F.
+	// For example an X is isomorphic for all configurations, and F is anisomorphic for all configurations.
+	// The cardinality of a tile represents the the set size for all configurations.
+	// So X has a cardinality of 1, since doesn't matter what operations we perform, we get the same tile.
 	class Tile
 	{
 	public:
 		Tile(int id, string name = "", char symmetry = 'X', int configuration = 0);
+		
+		//rotate tile 90 degrees clockwise
 		void rotate();
+
+		//mirror tile horizontally
 		void reflect();
+
+		// getters
 		const int id() const { return m_id; };
-		const int configuration() const { return m_configuration; };	
-		static const Tile INVALID;
+		const int configuration() const { return m_configuration; };
 
 	private:
 		int m_id;
@@ -22,7 +39,11 @@ namespace Vertexy
 		char m_symmetry;
 		int m_configuration;
 		int m_cardinality;
+
+		//rotation
 		function<int(int)> m_a;
+
+		//reflection
 		function<int(int)> m_b;
 	};
 }

--- a/vertexyTestHarness/src/SolverTest.cpp
+++ b/vertexyTestHarness/src/SolverTest.cpp
@@ -299,6 +299,7 @@ int main(int argc, char* argv[])
 	Suite.AddTest("NQueens-Table", []() { return NQueensSolvers::solveUsingTable(NUM_TIMES, NQUEENS_SIZE, FORCE_SEED, PRINT_VERBOSE); });
 	Suite.AddTest("NQueens-Graph", []() { return NQueensSolvers::solveUsingGraph(NUM_TIMES, NQUEENS_SIZE, FORCE_SEED, PRINT_VERBOSE); });*/
 	Suite.AddTest("PrefabTest-Basic", []() { return PrefabTestSolver::solveBasic(NUM_TIMES, FORCE_SEED, PRINT_VERBOSE); });
+	Suite.AddTest("PrefabTest-Rot/Refl", []() { return PrefabTestSolver::solveRotationReflection(NUM_TIMES, FORCE_SEED, PRINT_VERBOSE); });
 	/*Suite.AddTest("MazeProgram", []() { return MazeSolver::solveProgram(NUM_TIMES, MAZE_NUM_ROWS, MAZE_NUM_COLS, FORCE_SEED, PRINT_VERBOSE); });
 	Suite.AddTest("Maze", []() { return MazeSolver::solveKeyDoor(NUM_TIMES, MAZE_NUM_ROWS, MAZE_NUM_COLS, FORCE_SEED, PRINT_VERBOSE); });*/
 	return Suite.Run();

--- a/vertexyTestHarness/src/SolverTest.cpp
+++ b/vertexyTestHarness/src/SolverTest.cpp
@@ -264,7 +264,7 @@ static constexpr int NQUEENS_SIZE = 25;
 static constexpr int SUDOKU_STARTING_HINTS = 0;
 static constexpr int TOWERS_NUM_DISCS = 3;
 static constexpr int KNIGHT_BOARD_DIM = 6;
-static constexpr bool PRINT_VERBOSE = true;
+static constexpr bool PRINT_VERBOSE = false;
 
 int main(int argc, char* argv[])
 {
@@ -272,7 +272,7 @@ int main(int argc, char* argv[])
 	using namespace VertexyTests;
 	
 	TestApplication Suite("Solver Tests", argc, argv);
-	/*Suite.AddTest("ValueBitset", test_ValueBitset);
+	Suite.AddTest("ValueBitset", test_ValueBitset);
 	Suite.AddTest("Digraph", test_Digraph);
 	Suite.AddTest("RuleSCCs", test_ruleSCCs);
 	Suite.AddTest("Clause-Basic", []() { return TestSolvers::solveClauseBasic(NUM_TIMES, FORCE_SEED, PRINT_VERBOSE); });
@@ -297,10 +297,10 @@ int main(int argc, char* argv[])
 	Suite.AddTest("KnightTour", []() { return KnightTourSolver::solveAtomic(NUM_TIMES, KNIGHT_BOARD_DIM, FORCE_SEED, PRINT_VERBOSE); });
 	Suite.AddTest("NQueens-AllDifferent", []() { return NQueensSolvers::solveUsingAllDifferent(NUM_TIMES, NQUEENS_SIZE, FORCE_SEED, PRINT_VERBOSE); });
 	Suite.AddTest("NQueens-Table", []() { return NQueensSolvers::solveUsingTable(NUM_TIMES, NQUEENS_SIZE, FORCE_SEED, PRINT_VERBOSE); });
-	Suite.AddTest("NQueens-Graph", []() { return NQueensSolvers::solveUsingGraph(NUM_TIMES, NQUEENS_SIZE, FORCE_SEED, PRINT_VERBOSE); });*/
+	Suite.AddTest("NQueens-Graph", []() { return NQueensSolvers::solveUsingGraph(NUM_TIMES, NQUEENS_SIZE, FORCE_SEED, PRINT_VERBOSE); });
 	Suite.AddTest("PrefabTest-Basic", []() { return PrefabTestSolver::solveBasic(NUM_TIMES, FORCE_SEED, PRINT_VERBOSE); });
 	Suite.AddTest("PrefabTest-Rot/Refl", []() { return PrefabTestSolver::solveRotationReflection(NUM_TIMES, FORCE_SEED, PRINT_VERBOSE); });
-	/*Suite.AddTest("MazeProgram", []() { return MazeSolver::solveProgram(NUM_TIMES, MAZE_NUM_ROWS, MAZE_NUM_COLS, FORCE_SEED, PRINT_VERBOSE); });
-	Suite.AddTest("Maze", []() { return MazeSolver::solveKeyDoor(NUM_TIMES, MAZE_NUM_ROWS, MAZE_NUM_COLS, FORCE_SEED, PRINT_VERBOSE); });*/
+	Suite.AddTest("MazeProgram", []() { return MazeSolver::solveProgram(NUM_TIMES, MAZE_NUM_ROWS, MAZE_NUM_COLS, FORCE_SEED, PRINT_VERBOSE); });
+	Suite.AddTest("Maze", []() { return MazeSolver::solveKeyDoor(NUM_TIMES, MAZE_NUM_ROWS, MAZE_NUM_COLS, FORCE_SEED, PRINT_VERBOSE); });
 	return Suite.Run();
 }

--- a/vertexyTestHarness/src/SolverTest.cpp
+++ b/vertexyTestHarness/src/SolverTest.cpp
@@ -264,7 +264,7 @@ static constexpr int NQUEENS_SIZE = 25;
 static constexpr int SUDOKU_STARTING_HINTS = 0;
 static constexpr int TOWERS_NUM_DISCS = 3;
 static constexpr int KNIGHT_BOARD_DIM = 6;
-static constexpr bool PRINT_VERBOSE = false;
+static constexpr bool PRINT_VERBOSE = true;
 
 int main(int argc, char* argv[])
 {
@@ -272,7 +272,7 @@ int main(int argc, char* argv[])
 	using namespace VertexyTests;
 	
 	TestApplication Suite("Solver Tests", argc, argv);
-	Suite.AddTest("ValueBitset", test_ValueBitset);
+	/*Suite.AddTest("ValueBitset", test_ValueBitset);
 	Suite.AddTest("Digraph", test_Digraph);
 	Suite.AddTest("RuleSCCs", test_ruleSCCs);
 	Suite.AddTest("Clause-Basic", []() { return TestSolvers::solveClauseBasic(NUM_TIMES, FORCE_SEED, PRINT_VERBOSE); });
@@ -297,9 +297,9 @@ int main(int argc, char* argv[])
 	Suite.AddTest("KnightTour", []() { return KnightTourSolver::solveAtomic(NUM_TIMES, KNIGHT_BOARD_DIM, FORCE_SEED, PRINT_VERBOSE); });
 	Suite.AddTest("NQueens-AllDifferent", []() { return NQueensSolvers::solveUsingAllDifferent(NUM_TIMES, NQUEENS_SIZE, FORCE_SEED, PRINT_VERBOSE); });
 	Suite.AddTest("NQueens-Table", []() { return NQueensSolvers::solveUsingTable(NUM_TIMES, NQUEENS_SIZE, FORCE_SEED, PRINT_VERBOSE); });
-	Suite.AddTest("NQueens-Graph", []() { return NQueensSolvers::solveUsingGraph(NUM_TIMES, NQUEENS_SIZE, FORCE_SEED, PRINT_VERBOSE); });
+	Suite.AddTest("NQueens-Graph", []() { return NQueensSolvers::solveUsingGraph(NUM_TIMES, NQUEENS_SIZE, FORCE_SEED, PRINT_VERBOSE); });*/
 	Suite.AddTest("PrefabTest-Basic", []() { return PrefabTestSolver::solveBasic(NUM_TIMES, FORCE_SEED, PRINT_VERBOSE); });
-	Suite.AddTest("MazeProgram", []() { return MazeSolver::solveProgram(NUM_TIMES, MAZE_NUM_ROWS, MAZE_NUM_COLS, FORCE_SEED, PRINT_VERBOSE); });
-	Suite.AddTest("Maze", []() { return MazeSolver::solveKeyDoor(NUM_TIMES, MAZE_NUM_ROWS, MAZE_NUM_COLS, FORCE_SEED, PRINT_VERBOSE); });
+	/*Suite.AddTest("MazeProgram", []() { return MazeSolver::solveProgram(NUM_TIMES, MAZE_NUM_ROWS, MAZE_NUM_COLS, FORCE_SEED, PRINT_VERBOSE); });
+	Suite.AddTest("Maze", []() { return MazeSolver::solveKeyDoor(NUM_TIMES, MAZE_NUM_ROWS, MAZE_NUM_COLS, FORCE_SEED, PRINT_VERBOSE); });*/
 	return Suite.Run();
 }

--- a/vertexyTests/src/public/PrefabTest.h
+++ b/vertexyTests/src/public/PrefabTest.h
@@ -18,6 +18,7 @@ namespace VertexyTests
 
 	public:
 		static int solveBasic(int times, int seed, bool printVerbose = true);
+		static int solveRotationReflection(int times, int seed, bool printVerbose = true);
 
 		static int check(ConstraintSolver* solver, shared_ptr<TTopologyVertexData<VarID>> tileData, const shared_ptr<PrefabManager>& prefabManager);
 		static void print(ConstraintSolver* solver, shared_ptr<PlanarGridTopology> grid, shared_ptr<TTopologyVertexData<VarID>> tileData, const shared_ptr<PrefabManager>& prefabManager);


### PR DESCRIPTION
-Adds a tile class. Now prefab is a matrix of tiles instead of integers.
-Adds rotation and reflection to prefab.
-Moves constrains creation from prefab to prefab manager, remove prefab dependency on prefab manager.
-createPrefab now allow rotation and reflection.
-Adds "PrefabTest-Rot/Refl" test.